### PR TITLE
Improve Cloudinary component support and converter robustness

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -12,22 +12,28 @@ $rules = [
     'blank_line_before_statement' => [
         'statements' => ['return'],
     ],
-    'braces' => true,
+    'braces_position' => true,
     'cast_spaces' => true,
     'class_attributes_separation' => [
-        'elements' => ['method'],
+        'elements' => [
+            'method' => 'one',
+            'trait_import' => 'none',
+        ],
     ],
     'class_definition' => true,
     'concat_space' => [
         'spacing' => 'none',
     ],
+    'control_structure_braces' => true,
+    'control_structure_continuation_position' => true,
+    'declare_parentheses' => true,
     'declare_equal_normalize' => true,
     'elseif' => true,
     'encoding' => true,
     'full_opening_tag' => true,
     'fully_qualified_strict_types' => true, // added by Shift
     'function_declaration' => true,
-    'function_typehint_space' => true,
+    'type_declaration_spaces' => true,
     'heredoc_to_nowdoc' => true,
     'include' => true,
     'increment_style' => ['style' => 'post'],
@@ -48,7 +54,6 @@ $rules = [
             'extra',
             'throw',
             'use',
-            'use_trait',
         ],
     ],
     'no_blank_lines_after_class_opening' => true,
@@ -69,9 +74,10 @@ $rules = [
     'no_singleline_whitespace_before_semicolons' => true,
     'no_spaces_after_function_name' => true,
     'no_spaces_around_offset' => true,
-    'no_spaces_inside_parenthesis' => true,
-    'no_trailing_comma_in_list_call' => true,
-    'no_trailing_comma_in_singleline_array' => true,
+    'spaces_inside_parentheses' => ['space' => 'none'],
+    'no_trailing_comma_in_singleline' => [
+        'elements' => ['arguments', 'array'],
+    ],
     'no_trailing_whitespace' => true,
     'no_trailing_whitespace_in_comment' => true,
     'no_unneeded_control_parentheses' => true,
@@ -85,7 +91,7 @@ $rules = [
     'object_operator_without_whitespace' => true,
     'ordered_imports' => ['sort_algorithm' => 'alpha'],
     'phpdoc_indent' => true,
-    'phpdoc_inline_tag' => true,
+    'phpdoc_inline_tag_normalizer' => true,
     'phpdoc_no_access' => true,
     'phpdoc_no_package' => true,
     'phpdoc_no_useless_inheritdoc' => true,
@@ -101,13 +107,17 @@ $rules = [
     'short_scalar_cast' => true,
     'simplified_null_return' => false, // disabled by Shift
     'single_blank_line_at_eof' => true,
-    'single_blank_line_before_namespace' => true,
+    'blank_lines_before_namespace' => [
+        'min_line_breaks' => 1,
+        'max_line_breaks' => 1,
+    ],
     'single_class_element_per_statement' => true,
     'single_import_per_statement' => true,
     'single_line_after_imports' => true,
     'single_line_comment_style' => [
         'comment_types' => ['hash'],
     ],
+    'single_space_around_construct' => true,
     'single_quote' => true,
     'space_after_semicolon' => true,
     'standardize_not_equals' => true,
@@ -117,7 +127,7 @@ $rules = [
     'trailing_comma_in_multiline' => true,
     'trim_array_spaces' => true,
     'unary_operator_spaces' => true,
-    'visibility_required' => [
+    'modifier_keywords' => [
         'elements' => ['method', 'property'],
     ],
     'whitespace_after_comma_in_array' => true,
@@ -131,7 +141,7 @@ $finder = PhpCsFixer\Finder::create()
     ->ignoreDotFiles(true)
     ->ignoreVCS(true);
 
-return PhpCsFixer\Config::create()
+return (new PhpCsFixer\Config())
     ->setFinder($finder)
     ->setRules($rules)
     ->setRiskyAllowed(true)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,209 +1,211 @@
 # AGENTS.md
 
-Anleitung fuer Coding-Agents in `tfd/statamic-cloudinary`.
+Guidance for coding agents working in `tfd/statamic-cloudinary`.
 
-## Projektueberblick
+## Project Overview
 
-- Dieses Repository ist ein PHP-Paket fuer Statamic/Laravel.
-- Paketname: `tfd/statamic-cloudinary`.
-- PSR-4-Root-Namespace: `TFD\Cloudinary\`, gemappt auf `src/`.
-- Der Hauptcode liegt in `src/`.
-- Die Laufzeitkonfiguration liegt in `config/cloudinary.php`.
-- Blade-Views liegen in `resources/views/`.
-- Es gibt aktuell keine Frontend-Build-Pipeline fuer dieses Addon.
-- Testsuite: Pest unter `tests/` (Orchestra Testbench), z. B. `tests/Unit/CloudinaryConverterTest.php`.
+- This repository is a PHP package for Statamic/Laravel.
+- Package name: `tfd/statamic-cloudinary`.
+- PSR-4 root namespace: `TFD\Cloudinary\`, mapped to `src/`.
+- Main source code lives in `src/`.
+- Package runtime config lives in `config/cloudinary.php` and is published to `config/statamic/cloudinary.php`.
+- Blade views live in `resources/views/`.
+- There is no frontend build pipeline for this addon.
+- Tests use Pest with Orchestra Testbench in `tests/`, for example `tests/Unit/CloudinaryConverterTest.php`.
 
-## Quellen Fuer Agent-Regeln
+## Rule Sources
 
-- Vor dieser Datei gab es kein Repository-weites `AGENTS.md`.
-- Es wurde keine `.cursorrules`-Datei gefunden.
-- Es wurden keine Dateien in `.cursor/rules/` gefunden.
-- Es wurde keine `.github/copilot-instructions.md` gefunden.
-- Falls spaeter solche Dateien hinzukommen, gelten sie als zusaetzliche Anweisungen.
+- Before this file, there was no repository-wide `AGENTS.md`.
+- No `.cursorrules` file was found.
+- No files were found in `.cursor/rules/`.
+- No `.github/copilot-instructions.md` file was found.
+- If any of these files are added later, treat them as additional instructions.
 
-## Umgebung Und Tooling
+## Environment And Tooling
 
-- Paketmanager: Composer.
-- Formatter/Linter: PHP CS Fixer ueber `.php-cs-fixer.php`.
-- Dev-Dependencies: u. a. `pestphp/pest`, `orchestra/testbench`, `mockery/mockery`, `phpunit/phpunit`.
-- Das Paket zielt auf Statamic `^5.73.11 || ^6.4`.
-- Laravel-Helper wie `config()`, `resource_path()` und `collect()` koennen vorausgesetzt werden.
+- Package manager: Composer.
+- Formatter/linter: PHP CS Fixer via `.php-cs-fixer.php`.
+- Dev dependencies include `pestphp/pest`, `orchestra/testbench`, `mockery/mockery`, and `phpunit/phpunit`.
+- The package targets Statamic `^5.73.11 || ^6.4`.
+- Laravel helpers such as `config()`, `resource_path()`, and `collect()` can be assumed.
 
-## Setup-Befehle
+## Setup Commands
 
-Abhaengigkeiten installieren:
+Install dependencies:
 
 ```bash
 composer install
 ```
 
-Nur Produktions-Abhaengigkeiten installieren:
+Install production dependencies only:
 
 ```bash
 composer install --no-dev
 ```
 
-Composer-Autoload nach Namespace- oder Dateiaenderungen aktualisieren:
+Refresh Composer autoloads after namespace or file changes:
 
 ```bash
 composer dump-autoload
 ```
 
-## Build-Befehle
+## Build Commands
 
-- Es gibt keinen dedizierten Build-Schritt fuer dieses Paket.
-- `composer install` und `composer dump-autoload` sind die relevanten Setup-/Build-aehnlichen Befehle.
-- Fuer eine Paketvalidierung kann Composer selbst verwendet werden:
+- There is no dedicated build step for this package.
+- `composer install` and `composer dump-autoload` are the closest setup/build-like commands.
+- For package validation, use:
 
 ```bash
 composer validate
 ```
 
-## Lint- Und Formatierungsbefehle
+## Linting And Formatting
 
-Repository-definierter Lint-Befehl:
+Repository lint command:
 
 ```bash
 composer lint
 ```
 
-Das expandiert zu:
+This expands to:
 
 ```bash
 php ./vendor/bin/php-cs-fixer fix -v --config .php-cs-fixer.php
 ```
 
-Sichere Check-only-Variante vor Aenderungen:
+Safe check-only variant:
 
 ```bash
 php ./vendor/bin/php-cs-fixer fix --dry-run --diff -v --config .php-cs-fixer.php
 ```
 
-## Test-Befehle
+## Test Commands
 
-Alle Tests (Pest):
+Run all tests:
 
 ```bash
 composer test
 ```
 
-Entspricht:
+Equivalent command:
 
 ```bash
 ./vendor/bin/pest
 ```
 
-Mit PHPUnit-Filter (Pest nutzt PHPUnit darunter):
+Run filtered tests:
 
 ```bash
 ./vendor/bin/pest --filter=CloudinaryConverter
 ```
 
-Konfiguration: `phpunit.xml` im Repository-Root; `tests/Pest.php` bindet `Tests\TestCase` (Orchestra Testbench) fuer `tests/Unit`.
+Test config lives in `phpunit.xml`; `tests/Pest.php` binds `Tests\TestCase` for `tests/Unit`.
 
-## Dateien Und Verantwortlichkeiten
+## Files And Responsibilities
 
-- `src/ServiceProvider.php`: Paketregistrierung, Publish-Definitionen, Blade-Komponenten, Laden von Views.
-- `src/Converter/CloudinaryConverter.php`: zentrale Transformations- und URL-Generierungslogik.
-- `src/Tags/Cloudinary.php`: Statamic-Tag-Implementierung und Glide-Fallback-Verhalten.
-- `src/Components/Image.php`: Blade-Komponente als Wrapper um den Converter.
-- `src/Interfaces/CloudinaryInterface.php`: kleines gemeinsames Interface.
-- `config/cloudinary.php`: Paket-Defaults und Konfigurationsverdrahtung.
-- `resources/views/components/image.blade.php`: gerendertes Bild-Markup.
+- `src/ServiceProvider.php`: package registration, config merge for `statamic.cloudinary`, publish definitions, view namespace `cloudinary`, Blade component registration.
+- `src/Converter/CloudinaryConverter.php`: core transformation and URL generation logic.
+- `src/Tags/Cloudinary.php`: Statamic tag implementation and Glide fallback behavior.
+- `src/Components/Image.php`: Blade component wrapper around the converter.
+- `src/Interfaces/CloudinaryInterface.php`: small shared interface.
+- `config/cloudinary.php`: package defaults and config wiring.
+- `resources/views/components/cloudinary-image.blade.php`: rendered markup for `<x-cloudinary-image />`.
 
-## Grundsaetzlicher Code-Style
+## Code Style
 
-Orientiere dich zuerst am bestehenden Stil im Repository und lasse das Ergebnis anschliessend von PHP CS Fixer normalisieren.
+Follow the existing repository style first, then normalize with PHP CS Fixer.
 
-- Verwende PSR-4-Namespaces unter `TFD\Cloudinary`.
-- Verwende Short-Array-Syntax: `[]`.
-- Verwende einfache Anfuehrungszeichen, ausser Interpolation oder Escaping machen doppelte Anfuehrungszeichen klarer.
-- Ein Import pro Statement.
-- Imports alphabetisch sortieren.
-- Ungenutzte Imports entfernen.
-- Genau eine Leerzeile nach dem Namespace und nach dem Import-Block.
-- Explizite Sichtbarkeit fuer Methoden und Properties.
-- Moeglichst ein Klassen-Element pro Statement.
-- Dateien mit genau einer abschliessenden Leerzeile beenden.
-- Kein schliessendes `?>` in PHP-Dateien.
+- Use PSR-4 namespaces under `TFD\Cloudinary`.
+- Keep `declare(strict_types=1);` in new or already modernized PHP files.
+- Use short arrays: `[]`.
+- Prefer single quotes unless interpolation or escaping makes double quotes clearer.
+- Use one import per statement.
+- Keep imports alphabetized.
+- Remove unused imports.
+- Leave exactly one blank line after the namespace and after the import block.
+- Use explicit visibility for methods and properties.
+- Prefer one class member per statement.
+- End files with exactly one trailing newline.
+- Do not use a closing `?>` tag in PHP files.
 
 ## Imports
 
-- Framework- und Paketklassen am Dateianfang importieren.
-- Import-Aliasse nur verwenden, wenn Namenskonflikte oder Verwechslungen drohen, z. B. `Asset as AssetsAsset`.
-- Vollqualifizierte Klassennamen im Inline-Code vermeiden, wenn ein `use`-Statement klarer ist.
-- Der Fixer erzwingt keine fuehrenden Import-Slashes und alphabetische Sortierung.
+- Import framework and package classes at the top of the file.
+- Use import aliases only when needed to avoid collisions or confusion, for example `Asset as AssetsAsset`.
+- Avoid inline fully qualified class names when a `use` statement is clearer.
+- The fixer does not enforce leading import slashes and may not guarantee alphabetic ordering on its own.
 
-## Formatierung
+## Formatting
 
-- Die bestehende Einrueckung mit 4 Leerzeichen beibehalten.
-- Klammern und Methodenlayout konsistent zum restlichen Code halten.
-- Leerzeilen nur zwischen logischen Bloecken einsetzen, nicht stapeln.
-- Einfache Delegationsmethoden kompakt halten.
-- Mehrzeilige Arrays verwenden, wenn die Lesbarkeit steigt.
-- Trailing Commas in mehrzeiligen Arrays beibehalten.
-- String-Konkatenation ohne zusaetzliche Leerzeichen um `.` schreiben.
+- Keep 4-space indentation.
+- Match existing brace style and method layout.
+- Use blank lines only between logical blocks.
+- Keep simple delegation methods compact.
+- Use multiline arrays when they improve readability.
+- Keep trailing commas in multiline arrays.
+- Concatenate strings without extra spaces around `.`.
 
-## Typen Und Signaturen
+## Types And Signatures
 
-- Die bestehende Codebasis verwendet nur wenige PHP-Typdeklarationen.
-- Beim Bearbeiten vorhandener Dateien die Kompatibilitaet zum umgebenden Code bewahren.
-- Keine aggressiven Scalar-Type-Hints oder Return-Types ueber das ganze Paket verteilen, sofern nicht alle betroffenen Verwendungen konsistent angepasst werden.
-- Constructor Dependency Injection ist das bevorzugte Muster fuer Services und Komponenten.
-- Bei neuen APIs Typen bevorzugen, wenn sie fuer die unterstuetzte PHP-/Laravel-/Statamic-Matrix offensichtlich sicher sind.
-- `Collection` bewusst einsetzen, wenn eine Methode bereits in Collection-Begriffen arbeitet.
+- The codebase is mixed: older files are looser, newer files use `strict_types`, typed properties, and return types.
+- Preserve compatibility with the surrounding code when editing existing files, but do not remove modern typing from already typed files.
+- Do not add scalar type hints or return types broadly unless all affected usage is updated consistently.
+- Prefer constructor dependency injection for services and components.
+- Prefer types on new APIs when they are clearly safe for the supported PHP/Laravel/Statamic matrix.
+- Use `Collection` deliberately when a method already works in collection terms.
 
-## Benennungskonventionen
+## Naming
 
-- Klassen verwenden PascalCase.
-- Methoden und Properties verwenden camelCase.
-- Config-Keys und Array-Keys verwenden snake_case, wenn sie externe Konfiguration oder Cloudinary-Parameter abbilden.
-- Begriffe an Statamic- und Cloudinary-Terminologie ausrichten: `asset`, `tag`, `transformations`, `delivery_type`, `fetch_format`.
-- Namespace-Ordner sollen den Zweck der Klassen widerspiegeln, z. B. `Tags`, `Components`, `Converter`, `Interfaces`.
+- Classes use PascalCase.
+- Methods and properties use camelCase.
+- Config keys and array keys use snake_case when mirroring external configuration or Cloudinary parameters.
+- Align terminology with Statamic and Cloudinary, such as `asset`, `tag`, `transformations`, `delivery_type`, and `fetch_format`.
+- Namespace directories should reflect intent, for example `Tags`, `Components`, `Converter`, and `Interfaces`.
 
-## Fehlerbehandlung Und Logging
+## Error Handling And Logging
 
-- Wenn moeglich, graceful Fallbacks statt harter Fehler verwenden, insbesondere wenn an Statamic Glide delegiert werden kann.
-- Der bestehende Code faengt `ItemNotFoundException` ab und loggt ueber `Log::error(...)`.
-- Fallback-Pfade intakt lassen, wenn Konfiguration fehlt oder Asset-Lookups fehlschlagen.
-- Logging fuer operative Probleme verwenden, die das Rendering nicht komplett abbrechen sollen.
-- Exceptions nicht stillschweigend schlucken, ausser es gibt einen klaren Grund; wenn Schweigen notwendig ist, Verhalten dokumentieren oder das etablierte Muster beibehalten.
+- Prefer graceful fallbacks over hard failures, especially when delegating to Statamic Glide is possible.
+- Existing code catches `ItemNotFoundException` and logs with `Log::error(...)`.
+- Preserve fallback paths when configuration is missing or asset lookups fail.
+- Use logging for operational problems that should not fully break rendering.
+- Do not silently swallow exceptions unless there is a clear reason and it matches the established pattern.
 
-## Paketspezifische Konventionen
+## Package-Specific Conventions
 
-- Vor der Generierung von Cloudinary-URLs immer die Konfiguration validieren.
-- Das Glide-Fallback in `src/Tags/Cloudinary.php` erhalten, wenn Cloudinary nicht verfuegbar ist.
-- Die Uebersetzung von Parametern zentral in `CloudinaryConverter` halten.
-- Statamic-Asset-IDs, Asset-URLs und gemappte externe URLs als unterstuetzte Inputs behandeln.
-- Publish-Pfade fuer Assets/Views und bestehende Tag-Namen nur aendern, wenn bewusst ein Breaking Change gewollt ist.
+- Always validate configuration before generating Cloudinary URLs.
+- Preserve the Glide fallback in `src/Tags/Cloudinary.php` when Cloudinary is unavailable.
+- Keep parameter translation centralized in `CloudinaryConverter`.
+- Treat Statamic asset IDs, asset URLs, and mapped external URLs as supported inputs.
+- Do not change config/view publish paths, the `cloudinary` view namespace, or existing tag/component names unless a breaking change is intentional.
 
-## Blade- Und View-Konventionen
+## Blade And View Conventions
 
-- Blade-Komponenten-Ausgabe einfach und vorhersagbar halten.
-- Dynamische Werte mit normaler Blade-Escaping-Syntax `{{ }}` ausgeben.
-- Vorbereitete View-Daten bevorzugt in PHP uebergeben, statt Transformationslogik in Blade zu verstecken.
-- HTML-Attribute explizit halten, wenn sie Ausgabedimensionen oder Accessibility beeinflussen.
+- Keep Blade component output simple and predictable.
+- Output dynamic values with normal Blade escaping via `{{ }}`.
+- Prefer preparing view data in PHP rather than hiding transformation logic in Blade.
+- Keep HTML attributes explicit when they affect dimensions or accessibility.
+- The current Blade component is `<x-cloudinary-image />`; keep alias, view path, and docs in sync if it changes.
 
-## Beim Aendern Von Code
+## When Editing Code
 
-- Die kleinstmoegliche Aenderung machen, die das Problem loest.
-- Breite Refactorings vermeiden, ausser die Aufgabe verlangt es.
-- Neue Tests unter `tests/` ablegen; `composer test` ausfuehren (siehe Abschnitt Test-Befehle).
-- Wenn du Formatierung spuerbar veraenderst, anschliessend PHP CS Fixer ausfuehren.
-- Wenn du neue Klassen unter `src/` hinzufuegst, sicherstellen, dass Namespace und Pfad zu PSR-4 passen.
-- `README.md` aktualisieren, wenn sich oeffentliches Verhalten oder Konfiguration aendert.
+- Make the smallest change that solves the problem.
+- Avoid broad refactors unless the task requires them.
+- Add new tests under `tests/` and run `composer test`.
+- If formatting changes materially, run PHP CS Fixer afterward.
+- When adding new classes under `src/`, ensure path and namespace match PSR-4.
+- Update `README.md` when public behavior or configuration changes.
 
-## Worauf Besonders Zu Achten Ist
+## Watchouts
 
-- Einige aktuelle Dateien haben uneinheitliche Abstaende; beim Bearbeiten fixer-konforme Formatierung bevorzugen.
-- `composer lint` veraendert Dateien, weil intern `php-cs-fixer fix` und kein Dry-Run verwendet wird.
-- Nach relevanten Aenderungen `composer test` ausfuehren.
-- Bei Aenderungen an generierten URLs, Fallback-Semantik oder Config-Key-Namen besonders vorsichtig sein.
+- Some files still have inconsistent spacing; prefer fixer-compliant formatting when touching them.
+- `composer lint` modifies files because it runs `php-cs-fixer fix`, not a dry run.
+- Run `composer test` after relevant changes.
+- Be especially careful with generated URLs, fallback semantics, and config key names.
 
-## Empfohlener Agent-Workflow
+## Recommended Workflow
 
-1. Relevante Datei und naheliegende Verwendungen vor dem Editieren lesen.
-2. Eine gezielte Aenderung im Stil bestehender Statamic-/Laravel-Muster vornehmen.
-3. Je nach Situation `composer lint` oder die Dry-Run-Variante ausfuehren.
-4. `composer test` oder gezielt `./vendor/bin/pest --filter=...` ausfuehren.
-5. Verhaltensaenderungen, Fallback-Auswirkungen und Konfigurationsfolgen knapp zusammenfassen.
+1. Read the target file and nearby usages before editing.
+2. Make a focused change that follows existing Statamic/Laravel patterns.
+3. Run `composer lint` or the dry-run variant as appropriate.
+4. Run `composer test` or a focused `./vendor/bin/pest --filter=...` command.
+5. Summarize behavior changes, fallback impact, and config implications briefly.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,209 @@
+# AGENTS.md
+
+Anleitung fuer Coding-Agents in `tfd/statamic-cloudinary`.
+
+## Projektueberblick
+
+- Dieses Repository ist ein PHP-Paket fuer Statamic/Laravel.
+- Paketname: `tfd/statamic-cloudinary`.
+- PSR-4-Root-Namespace: `TFD\Cloudinary\`, gemappt auf `src/`.
+- Der Hauptcode liegt in `src/`.
+- Die Laufzeitkonfiguration liegt in `config/cloudinary.php`.
+- Blade-Views liegen in `resources/views/`.
+- Es gibt aktuell keine Frontend-Build-Pipeline fuer dieses Addon.
+- Testsuite: Pest unter `tests/` (Orchestra Testbench), z. B. `tests/Unit/CloudinaryConverterTest.php`.
+
+## Quellen Fuer Agent-Regeln
+
+- Vor dieser Datei gab es kein Repository-weites `AGENTS.md`.
+- Es wurde keine `.cursorrules`-Datei gefunden.
+- Es wurden keine Dateien in `.cursor/rules/` gefunden.
+- Es wurde keine `.github/copilot-instructions.md` gefunden.
+- Falls spaeter solche Dateien hinzukommen, gelten sie als zusaetzliche Anweisungen.
+
+## Umgebung Und Tooling
+
+- Paketmanager: Composer.
+- Formatter/Linter: PHP CS Fixer ueber `.php-cs-fixer.php`.
+- Dev-Dependencies: u. a. `pestphp/pest`, `orchestra/testbench`, `mockery/mockery`, `phpunit/phpunit`.
+- Das Paket zielt auf Statamic `^5.73.11 || ^6.4`.
+- Laravel-Helper wie `config()`, `resource_path()` und `collect()` koennen vorausgesetzt werden.
+
+## Setup-Befehle
+
+Abhaengigkeiten installieren:
+
+```bash
+composer install
+```
+
+Nur Produktions-Abhaengigkeiten installieren:
+
+```bash
+composer install --no-dev
+```
+
+Composer-Autoload nach Namespace- oder Dateiaenderungen aktualisieren:
+
+```bash
+composer dump-autoload
+```
+
+## Build-Befehle
+
+- Es gibt keinen dedizierten Build-Schritt fuer dieses Paket.
+- `composer install` und `composer dump-autoload` sind die relevanten Setup-/Build-aehnlichen Befehle.
+- Fuer eine Paketvalidierung kann Composer selbst verwendet werden:
+
+```bash
+composer validate
+```
+
+## Lint- Und Formatierungsbefehle
+
+Repository-definierter Lint-Befehl:
+
+```bash
+composer lint
+```
+
+Das expandiert zu:
+
+```bash
+php ./vendor/bin/php-cs-fixer fix -v --config .php-cs-fixer.php
+```
+
+Sichere Check-only-Variante vor Aenderungen:
+
+```bash
+php ./vendor/bin/php-cs-fixer fix --dry-run --diff -v --config .php-cs-fixer.php
+```
+
+## Test-Befehle
+
+Alle Tests (Pest):
+
+```bash
+composer test
+```
+
+Entspricht:
+
+```bash
+./vendor/bin/pest
+```
+
+Mit PHPUnit-Filter (Pest nutzt PHPUnit darunter):
+
+```bash
+./vendor/bin/pest --filter=CloudinaryConverter
+```
+
+Konfiguration: `phpunit.xml` im Repository-Root; `tests/Pest.php` bindet `Tests\TestCase` (Orchestra Testbench) fuer `tests/Unit`.
+
+## Dateien Und Verantwortlichkeiten
+
+- `src/ServiceProvider.php`: Paketregistrierung, Publish-Definitionen, Blade-Komponenten, Laden von Views.
+- `src/Converter/CloudinaryConverter.php`: zentrale Transformations- und URL-Generierungslogik.
+- `src/Tags/Cloudinary.php`: Statamic-Tag-Implementierung und Glide-Fallback-Verhalten.
+- `src/Components/Image.php`: Blade-Komponente als Wrapper um den Converter.
+- `src/Interfaces/CloudinaryInterface.php`: kleines gemeinsames Interface.
+- `config/cloudinary.php`: Paket-Defaults und Konfigurationsverdrahtung.
+- `resources/views/components/image.blade.php`: gerendertes Bild-Markup.
+
+## Grundsaetzlicher Code-Style
+
+Orientiere dich zuerst am bestehenden Stil im Repository und lasse das Ergebnis anschliessend von PHP CS Fixer normalisieren.
+
+- Verwende PSR-4-Namespaces unter `TFD\Cloudinary`.
+- Verwende Short-Array-Syntax: `[]`.
+- Verwende einfache Anfuehrungszeichen, ausser Interpolation oder Escaping machen doppelte Anfuehrungszeichen klarer.
+- Ein Import pro Statement.
+- Imports alphabetisch sortieren.
+- Ungenutzte Imports entfernen.
+- Genau eine Leerzeile nach dem Namespace und nach dem Import-Block.
+- Explizite Sichtbarkeit fuer Methoden und Properties.
+- Moeglichst ein Klassen-Element pro Statement.
+- Dateien mit genau einer abschliessenden Leerzeile beenden.
+- Kein schliessendes `?>` in PHP-Dateien.
+
+## Imports
+
+- Framework- und Paketklassen am Dateianfang importieren.
+- Import-Aliasse nur verwenden, wenn Namenskonflikte oder Verwechslungen drohen, z. B. `Asset as AssetsAsset`.
+- Vollqualifizierte Klassennamen im Inline-Code vermeiden, wenn ein `use`-Statement klarer ist.
+- Der Fixer erzwingt keine fuehrenden Import-Slashes und alphabetische Sortierung.
+
+## Formatierung
+
+- Die bestehende Einrueckung mit 4 Leerzeichen beibehalten.
+- Klammern und Methodenlayout konsistent zum restlichen Code halten.
+- Leerzeilen nur zwischen logischen Bloecken einsetzen, nicht stapeln.
+- Einfache Delegationsmethoden kompakt halten.
+- Mehrzeilige Arrays verwenden, wenn die Lesbarkeit steigt.
+- Trailing Commas in mehrzeiligen Arrays beibehalten.
+- String-Konkatenation ohne zusaetzliche Leerzeichen um `.` schreiben.
+
+## Typen Und Signaturen
+
+- Die bestehende Codebasis verwendet nur wenige PHP-Typdeklarationen.
+- Beim Bearbeiten vorhandener Dateien die Kompatibilitaet zum umgebenden Code bewahren.
+- Keine aggressiven Scalar-Type-Hints oder Return-Types ueber das ganze Paket verteilen, sofern nicht alle betroffenen Verwendungen konsistent angepasst werden.
+- Constructor Dependency Injection ist das bevorzugte Muster fuer Services und Komponenten.
+- Bei neuen APIs Typen bevorzugen, wenn sie fuer die unterstuetzte PHP-/Laravel-/Statamic-Matrix offensichtlich sicher sind.
+- `Collection` bewusst einsetzen, wenn eine Methode bereits in Collection-Begriffen arbeitet.
+
+## Benennungskonventionen
+
+- Klassen verwenden PascalCase.
+- Methoden und Properties verwenden camelCase.
+- Config-Keys und Array-Keys verwenden snake_case, wenn sie externe Konfiguration oder Cloudinary-Parameter abbilden.
+- Begriffe an Statamic- und Cloudinary-Terminologie ausrichten: `asset`, `tag`, `transformations`, `delivery_type`, `fetch_format`.
+- Namespace-Ordner sollen den Zweck der Klassen widerspiegeln, z. B. `Tags`, `Components`, `Converter`, `Interfaces`.
+
+## Fehlerbehandlung Und Logging
+
+- Wenn moeglich, graceful Fallbacks statt harter Fehler verwenden, insbesondere wenn an Statamic Glide delegiert werden kann.
+- Der bestehende Code faengt `ItemNotFoundException` ab und loggt ueber `Log::error(...)`.
+- Fallback-Pfade intakt lassen, wenn Konfiguration fehlt oder Asset-Lookups fehlschlagen.
+- Logging fuer operative Probleme verwenden, die das Rendering nicht komplett abbrechen sollen.
+- Exceptions nicht stillschweigend schlucken, ausser es gibt einen klaren Grund; wenn Schweigen notwendig ist, Verhalten dokumentieren oder das etablierte Muster beibehalten.
+
+## Paketspezifische Konventionen
+
+- Vor der Generierung von Cloudinary-URLs immer die Konfiguration validieren.
+- Das Glide-Fallback in `src/Tags/Cloudinary.php` erhalten, wenn Cloudinary nicht verfuegbar ist.
+- Die Uebersetzung von Parametern zentral in `CloudinaryConverter` halten.
+- Statamic-Asset-IDs, Asset-URLs und gemappte externe URLs als unterstuetzte Inputs behandeln.
+- Publish-Pfade fuer Assets/Views und bestehende Tag-Namen nur aendern, wenn bewusst ein Breaking Change gewollt ist.
+
+## Blade- Und View-Konventionen
+
+- Blade-Komponenten-Ausgabe einfach und vorhersagbar halten.
+- Dynamische Werte mit normaler Blade-Escaping-Syntax `{{ }}` ausgeben.
+- Vorbereitete View-Daten bevorzugt in PHP uebergeben, statt Transformationslogik in Blade zu verstecken.
+- HTML-Attribute explizit halten, wenn sie Ausgabedimensionen oder Accessibility beeinflussen.
+
+## Beim Aendern Von Code
+
+- Die kleinstmoegliche Aenderung machen, die das Problem loest.
+- Breite Refactorings vermeiden, ausser die Aufgabe verlangt es.
+- Neue Tests unter `tests/` ablegen; `composer test` ausfuehren (siehe Abschnitt Test-Befehle).
+- Wenn du Formatierung spuerbar veraenderst, anschliessend PHP CS Fixer ausfuehren.
+- Wenn du neue Klassen unter `src/` hinzufuegst, sicherstellen, dass Namespace und Pfad zu PSR-4 passen.
+- `README.md` aktualisieren, wenn sich oeffentliches Verhalten oder Konfiguration aendert.
+
+## Worauf Besonders Zu Achten Ist
+
+- Einige aktuelle Dateien haben uneinheitliche Abstaende; beim Bearbeiten fixer-konforme Formatierung bevorzugen.
+- `composer lint` veraendert Dateien, weil intern `php-cs-fixer fix` und kein Dry-Run verwendet wird.
+- Nach relevanten Aenderungen `composer test` ausfuehren.
+- Bei Aenderungen an generierten URLs, Fallback-Semantik oder Config-Key-Namen besonders vorsichtig sein.
+
+## Empfohlener Agent-Workflow
+
+1. Relevante Datei und naheliegende Verwendungen vor dem Editieren lesen.
+2. Eine gezielte Aenderung im Stil bestehender Statamic-/Laravel-Muster vornehmen.
+3. Je nach Situation `composer lint` oder die Dry-Run-Variante ausfuehren.
+4. `composer test` oder gezielt `./vendor/bin/pest --filter=...` ausfuehren.
+5. Verhaltensaenderungen, Fallback-Auswirkungen und Konfigurationsfolgen knapp zusammenfassen.

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ Usage with other parameters.
 />
 ```
 
-There is also a custom Blade component to use Cloudinary in your Blade templates. The `src` attribute is required. If Cloudinary is not configured or `src` is missing, the component outputs nothing.
+There is also a custom Blade component to use Cloudinary in your Blade templates. The `src` attribute is required. If Cloudinary is not configured or `src` is missing, the component outputs nothing. The current component alias is `<x-cloudinary-image />`; the legacy `<x-image />` alias and published `components/image.blade.php` override remain supported for backward compatibility.
 
 ### 5. Available parameters
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,18 @@
 # Cloudinary
 
-> Cloudinary is a Statamic addon that allows you to use cloudinary to deliver your assets.
+> Cloudinary is a Statamic addon that allows you to use [Cloudinary](https://cloudinary.com) to deliver your assets.
 
 ## Features
 
 This addon allows you to:
 
-- leverage the transformation and delivery power of cloudinary
-- usable with images and videos
-- automatically upload media to cloudinary
+- leverage the transformation and delivery power of Cloudinary
+- use images and videos with the same tag patterns
+- rely on Cloudinary auto-upload mapping so media can be delivered from Cloudinary after the first request
+
+## Requirements
+
+- Statamic `^5.73.11` or `^6.4` (same constraint as this package; PHP and Laravel versions follow your Statamic project)
 
 ## How to Install
 
@@ -25,7 +29,7 @@ Supported Statamic versions: `5.73.11+` and `6.4+`.
 ### 1. Create a Cloudinary Account
 
 Go to https://cloudinary.com and create a free account.  
-It is recommended to create a new folder inside cloudinary's Media Library that hosts all the media of your website.
+It is recommended to create a new folder inside Cloudinary's Media Library that hosts all the media of your website.
 
 Go to `Settings > Upload > Auto upload mapping` and fill out
 
@@ -47,10 +51,10 @@ php artisan vendor:publish --tag="cloudinary-config"
 
 This will create a `cloudinary.php` file inside `config/statamic`.
 
-### 3. Setup cloudinary variables
+### 3. Setup Cloudinary variables
 
-Enter at least the following data in the cloudinary.php file or use your project's .env file.  
-The `auto_mapping_folder` is the folder you've created during the first step.
+Enter at least the following data in `config/statamic/cloudinary.php` or use your project's `.env` file.  
+The `auto_mapping_folder` is the folder you've created during the first step.  
 The `url` is the API Environment variable you've copied from the first step.
 
 ```php
@@ -68,6 +72,14 @@ CLOUDINARY_CLOUD_NAME=xxx
 CLOUDINARY_AUTO_MAPPING_FOLDER=xxx
 CLOUDINARY_URL=cloudinary://xxx:xxx@xxx
 ```
+
+The published config file also includes optional keys used for uploads, delivery type, and defaults, for example:
+
+- `upload_url` — base upload/delivery URL (default `https://res.cloudinary.com/`)
+- `api_key`, `api_secret`, `upload_preset`, `notification_url` — for signed uploads or webhooks if you use them
+- `delivery_type` — defaults to `upload`; adjust if your delivery setup differs
+
+See the full `config/statamic/cloudinary.php` after publishing for all keys and defaults.
 
 #### 3.1. Using an External URL
 
@@ -90,15 +102,18 @@ CLOUDINARY_EXTERNAL_URL_PREFIX=https://my-external-asset-url.com
 
 For example, if you are using DigitalOcean Spaces storage and your assets are served from this URL:  
 `https://my-project.us1.digitaloceanspaces.com/website/image.jpg`, the external URL consists of two parts:
+
 - `https://my-project.us1.digitaloceanspaces.com` - The DigitalOcean base URL
 - `/website` - The root folder in DigitalOcean
 
 The actual value you need to set in the config or .env file would be:  
 `CLOUDINARY_EXTERNAL_URL_PREFIX=https://my-project.us1.digitaloceanspaces.com/website/`
 
-### 4. Use the cloudinary tag
+### 4. Use the Cloudinary tag
 
-You are now ready to use the cloudinary tag inside your views.
+You are now ready to use the Cloudinary tag inside your views.
+
+If Cloudinary is not configured correctly, the tag falls back to Statamic's Glide-based image handling. Failed asset lookups in non-pair tag usage may also fall back to Glide.
 
 #### Some examples
 
@@ -111,7 +126,7 @@ The image is transformed according to the default transformation parameters, see
 ---
 
 ```html
-<img src="{{ cloudinary:image width="800" height="500" }}">
+<img src="{{ cloudinary:image width="800" height="500" }}" />
 ```
 
 The image is resized to 800 x 500 px.
@@ -164,7 +179,7 @@ Usage with other parameters.
 />
 ```
 
-There is also a custom blade component to use cloudinary in your blade templates. The `src` attribute is required.
+There is also a custom Blade component to use Cloudinary in your Blade templates. The `src` attribute is required. If Cloudinary is not configured or `src` is missing, the component outputs nothing.
 
 ### 5. Available parameters
 
@@ -204,6 +219,7 @@ For more information about these parameters, head over to the [cloudinary docume
 | delay                |
 | density              |
 | fetch_format         |
+| format               |
 | gravity              |
 | prefix               |
 | page                 |
@@ -242,4 +258,4 @@ Run the following command from your project root:
 php artisan vendor:publish --tag="cloudinary-views"
 ```
 
-This will publish the cloudinary views to the `resources/views/vendor/cloudinary`folder.
+This will publish the Cloudinary views to the `resources/views/vendor/cloudinary` folder.

--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,14 @@
       "TFD\\Cloudinary\\": "src"
     }
   },
+  "autoload-dev": {
+    "psr-4": {
+      "Tests\\": "tests/"
+    }
+  },
   "config": {
     "allow-plugins": {
+      "pestphp/pest-plugin": true,
       "pixelfear/composer-dist-plugin": true
     }
   },
@@ -27,10 +33,15 @@
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^3.88",
-    "phpunit/phpunit": "^10.5 || ^11.5",
+    "mockery/mockery": "^1.6",
+    "orchestra/testbench": "^9.0",
+    "pestphp/pest": "^2.36",
+    "pestphp/pest-plugin-laravel": "^2.4",
+    "phpunit/phpunit": "^10.5",
     "squizlabs/php_codesniffer": "^3.6"
   },
   "scripts": {
-    "lint": "@php ./vendor/bin/php-cs-fixer fix -v --config .php-cs-fixer.php"
+    "lint": "@php ./vendor/bin/php-cs-fixer fix -v --config .php-cs-fixer.php",
+    "test": "@php ./vendor/bin/pest"
   }
 }

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,10 @@
+# Run analysis from the consuming Laravel app (includes Larastan), e.g.:
+#   ./vendor/bin/phpstan analyse
+# with this package path listed in the app's phpstan.neon `paths`.
+#
+# Standalone: ./vendor/bin/phpstan analyse -c phpstan.neon.dist (requires dev deps).
+
+parameters:
+    level: 5
+    paths:
+        - src

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+>
+    <testsuites>
+        <testsuite name="Unit">
+            <directory>tests/Unit</directory>
+        </testsuite>
+    </testsuites>
+    <source>
+        <include>
+            <directory>src</directory>
+        </include>
+    </source>
+</phpunit>

--- a/resources/views/components/cloudinary-image.blade.php
+++ b/resources/views/components/cloudinary-image.blade.php
@@ -1,0 +1,2 @@
+<img src="{{ $url }}" alt="{{ $alt ?? '' }}" width="{{ $width }}"
+    height="{{ $height }}">

--- a/resources/views/components/image.blade.php
+++ b/resources/views/components/image.blade.php
@@ -1,1 +1,0 @@
-<img src="{{ $url }}" alt="{{ $alt ?? '' }}" width="{{ $width }}" height="{{ $height }}">

--- a/resources/views/components/image.blade.php
+++ b/resources/views/components/image.blade.php
@@ -1,0 +1,1 @@
+@include('cloudinary::components.cloudinary-image')

--- a/src/Components/Image.php
+++ b/src/Components/Image.php
@@ -1,7 +1,6 @@
 <?php
 
 declare(strict_types=1);
-
 namespace TFD\Cloudinary\Components;
 
 use Illuminate\Support\Facades\Log;

--- a/src/Components/Image.php
+++ b/src/Components/Image.php
@@ -63,7 +63,18 @@ class Image extends Component implements CloudinaryInterface
                 'height' => $height,
             ]));
 
-            return view('cloudinary::components.cloudinary-image', $viewData->toArray())->render();
+            return view($this->resolveViewName(), $viewData->toArray())->render();
         };
+    }
+
+    private function resolveViewName(): string
+    {
+        $legacyPublishedView = resource_path('views/vendor/cloudinary/components/image.blade.php');
+
+        if (file_exists($legacyPublishedView)) {
+            return 'cloudinary::components.image';
+        }
+
+        return 'cloudinary::components.cloudinary-image';
     }
 }

--- a/src/Components/Image.php
+++ b/src/Components/Image.php
@@ -1,17 +1,18 @@
 <?php
 
+declare(strict_types=1);
+
 namespace TFD\Cloudinary\Components;
 
-use Illuminate\View\Component;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\ItemNotFoundException;
+use Illuminate\View\Component;
 use Illuminate\View\ComponentAttributeBag;
 use TFD\Cloudinary\Converter\CloudinaryConverter;
 use TFD\Cloudinary\Interfaces\CloudinaryInterface;
 
 class Image extends Component implements CloudinaryInterface
 {
-
     protected $converter;
 
     public function __construct(CloudinaryConverter $converter)
@@ -19,36 +20,36 @@ class Image extends Component implements CloudinaryInterface
         $this->setConverter($converter);
     }
 
-    public function setConverter($converter)
+    public function setConverter(CloudinaryConverter $converter): void
     {
         $this->converter = $converter;
     }
 
-    public function render()
+    public function render(): mixed
     {
         if (! $this->converter->hasValidConfiguration()) {
-            return false;
+            return '';
         }
 
         return function (array $data) {
             /** @var ComponentAttributeBag */
             $attributeBag = $data['attributes'];
             $attributes = $attributeBag->getAttributes();
-            
-            if (!$attributeBag->has('src')) {
-                return false;
+
+            if (! $attributeBag->has('src')) {
+                return '';
             }
-            
+
             $this->converter->setParams($attributes);
-            
+
             $item = $attributeBag->get('src');
             $item = $this->converter->getAsset($item);
-            
+
             try {
                 $this->converter->setAssetType($item);
             } catch (ItemNotFoundException $e) {
                 Log::error($e->getMessage());
-    
+
                 return '';
             }
 
@@ -62,7 +63,7 @@ class Image extends Component implements CloudinaryInterface
                 'height' => $height,
             ]));
 
-            return view('cloudinary::components.image', $viewData->toArray())->render();
+            return view('cloudinary::components.cloudinary-image', $viewData->toArray())->render();
         };
     }
 }

--- a/src/Converter/CloudinaryConverter.php
+++ b/src/Converter/CloudinaryConverter.php
@@ -1,82 +1,41 @@
 <?php
 
+declare(strict_types=1);
+
 namespace TFD\Cloudinary\Converter;
 
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Log;
-use Statamic\Support\Str;
+use Illuminate\Support\ItemNotFoundException;
 use Statamic\Assets\Asset as AssetsAsset;
 use Statamic\Facades\Asset;
-use Illuminate\Support\ItemNotFoundException;
+use Statamic\Support\Str;
 
 class CloudinaryConverter
 {
-    protected static $config = null;
+    /**
+     * @var Collection<string, mixed>
+     */
+    protected Collection $configuration;
 
     /**
-     * @var Collection
+     * @var array<string, mixed>
      */
-    protected $configuration;
-
-    /**
-     * @var array
-     */
-    protected $params;
+    protected array $params = [];
 
     /**
      * @see https://cloudinary.com/documentation/transformation_reference
      *
-     * @var array|Collection
+     * @var Collection<string, string>
      */
-    protected $cloudinary_params = [
-        'angle' => 'a',
-        'aspect_ratio' => 'ar',
-        'background' => 'b',
-        'border' => 'bo',
-        'crop' => 'c',
-        'color' => 'co',
-        'dpr' => 'dpr',
-        'duration' => 'du',
-        'effect' => 'e',
-        'end_offset' => 'eo',
-        'flags' => 'fl',
-        'height' => 'h',
-        'overlay' => 'l',
-        'opacity' => 'o',
-        'quality' => 'q',
-        'radius' => 'r',
-        'start_offset' => 'so',
-        'named_transformation' => 't',
-        'underlay' => 'u',
-        'video_codec' => 'vc',
-        'width' => 'w',
-        'x' => 'x',
-        'y' => 'y',
-        'zoom' => 'z',
-        'audio_codec' => 'ac',
-        'audio_frequency' => 'af',
-        'bit_rate' => 'br',
-        'color_space' => 'cs',
-        'default_image' => 'd',
-        'delay' => 'dl',
-        'density' => 'dn',
-        'fetch_format' => 'f',
-        'gravity' => 'g',
-        'prefix' => 'p',
-        'page' => 'pg',
-        'video_sampling' => 'vs',
-        'progressive' => 'fl_progressive',
-    ];
+    protected Collection $cloudinary_params;
 
     /**
-     * @var Collection
+     * @var Collection<string, mixed>
      */
-    protected $default_transformations;
+    protected Collection $default_transformations;
 
-    /**
-     * @var string
-     */
-    protected $asset_type;
+    protected string $asset_type = '';
 
     public function __construct()
     {
@@ -85,17 +44,56 @@ class CloudinaryConverter
         $this->setDefaultTransformations();
     }
 
-    protected function setCloudinaryParams()
+    protected function setCloudinaryParams(): void
     {
-        $this->cloudinary_params = collect($this->cloudinary_params);
+        $this->cloudinary_params = collect([
+            'angle' => 'a',
+            'aspect_ratio' => 'ar',
+            'background' => 'b',
+            'border' => 'bo',
+            'crop' => 'c',
+            'color' => 'co',
+            'dpr' => 'dpr',
+            'duration' => 'du',
+            'effect' => 'e',
+            'end_offset' => 'eo',
+            'flags' => 'fl',
+            'height' => 'h',
+            'overlay' => 'l',
+            'opacity' => 'o',
+            'quality' => 'q',
+            'radius' => 'r',
+            'start_offset' => 'so',
+            'named_transformation' => 't',
+            'underlay' => 'u',
+            'video_codec' => 'vc',
+            'width' => 'w',
+            'x' => 'x',
+            'y' => 'y',
+            'zoom' => 'z',
+            'audio_codec' => 'ac',
+            'audio_frequency' => 'af',
+            'bit_rate' => 'br',
+            'color_space' => 'cs',
+            'default_image' => 'd',
+            'delay' => 'dl',
+            'density' => 'dn',
+            'fetch_format' => 'f',
+            'format' => 'f',
+            'gravity' => 'g',
+            'prefix' => 'p',
+            'page' => 'pg',
+            'video_sampling' => 'vs',
+            'progressive' => 'fl_progressive',
+        ]);
     }
 
-    protected function setConfiguration()
+    protected function setConfiguration(): void
     {
         $this->configuration = collect([
             'cloud_name' => config('statamic.cloudinary.cloud_name'),
             'cloudinary_upload_url' => config('statamic.cloudinary.upload_url'),
-            'auto_mapping_folder' => config('statamic.cloudinary.auto_mapping_folder'),
+            'auto_mapping_folder' => Str::finish((string) config('statamic.cloudinary.auto_mapping_folder'), '/'),
             'api_key' => config('statamic.cloudinary.api_key'),
             'api_secret' => config('statamic.cloudinary.api_secret'),
             'upload_preset' => config('statamic.cloudinary.upload_preset'),
@@ -106,41 +104,51 @@ class CloudinaryConverter
         ]);
     }
 
-    protected function setDefaultTransformations()
+    protected function setDefaultTransformations(): void
     {
-        $this->default_transformations = collect(config('statamic.cloudinary.default_transformations'));
+        /** @var array<string, mixed>|null $defaults */
+        $defaults = config('statamic.cloudinary.default_transformations');
+        $this->default_transformations = collect($defaults ?? []);
     }
 
-    public function setParams($params)
+    /**
+     * @param  array<string, mixed>|Collection<string, mixed>|iterable<string, mixed>  $params
+     */
+    public function setParams(mixed $params): void
     {
-        $this->params = $params;
+        if ($params instanceof Collection) {
+            $this->params = $params->all();
+        } elseif (is_array($params)) {
+            $this->params = $params;
+        } elseif (is_iterable($params)) {
+            $this->params = iterator_to_array($params);
+        } else {
+            $this->params = [];
+        }
     }
 
-    public function hasValidConfiguration()
+    public function hasValidConfiguration(): bool
     {
-        return $this->configuration->has('cloud_name') &&
-            $this->configuration->get('cloud_name') &&
+        return
+            $this->configuration->has('cloud_name') &&
+            (bool) $this->configuration->get('cloud_name') &&
             $this->configuration->has('cloudinary_upload_url') &&
-            $this->configuration->get('cloudinary_upload_url');
+            (bool) $this->configuration->get('cloudinary_upload_url');
     }
 
-    public function baseUrl($item)
+    public function baseUrl(): string
     {
-        return Str::ensureRight($this->configuration->get('cloudinary_upload_url'), '/') .
-            Str::ensureRight($this->configuration->get('cloud_name'), '/') .
-            $this->getAssetType() .
-            '/' .
-            $this->getDeliveryType() .
-            '/';
+        return
+            Str::ensureRight((string) $this->configuration->get('cloudinary_upload_url'), '/').
+            Str::ensureRight((string) $this->configuration->get('cloud_name'), '/').
+            Str::ensureRight($this->getAssetType(), '/').
+            Str::ensureRight((string) $this->getDeliveryType(), '/');
     }
 
     /**
      * @see https://cloudinary.com/documentation/image_transformations#transformation_url_structure
-     *
-     * @param $item
-     * @return void
      */
-    public function setAssetType($item)
+    public function setAssetType(mixed $item): void
     {
         $item = $this->getAsset($item);
 
@@ -153,29 +161,33 @@ class CloudinaryConverter
         }
     }
 
-    public function getAssetType()
+    public function getAssetType(): string
     {
         return $this->asset_type;
     }
 
-    public function getAsset($item)
+    public function getAsset(mixed $item): AssetsAsset
     {
         if ($item instanceof AssetsAsset) {
             return $item;
         }
 
-        if ($asset = Asset::findByUrl(Str::ensureLeft($item, '/'))) {
+        if ($asset = Asset::findByUrl(Str::ensureLeft((string) $item, '/'))) {
+            assert($asset instanceof AssetsAsset);
+
             return $asset;
         }
 
         if ($asset = Asset::find($item)) {
+            assert($asset instanceof AssetsAsset);
+
             return $asset;
         }
 
-        throw new ItemNotFoundException('Asset not found for ' . gettype($item));
+        throw new ItemNotFoundException('Asset not found for '.gettype($item));
     }
 
-    private function getDeliveryType()
+    private function getDeliveryType(): mixed
     {
         return $this->configuration->get('cloudinary_delivery_type');
     }
@@ -183,14 +195,13 @@ class CloudinaryConverter
     /**
      * The URL generation.
      *
-     * @param  string $item  Either the ID or path of the image.
-     * @return string
+     * @param  string|AssetsAsset  $item  Either the ID or path of the image.
      */
-    public function generateCloudinaryUrl($item)
+    public function generateCloudinaryUrl(mixed $item): string
     {
         $item = $this->getAsset($item);
         $url = $this->normalizeItem($item);
-        $manipulation_params = $this->getManipulationParams($item);
+        $manipulation_params = $this->getManipulationParams();
         $meta_params = $this->getMetaParams($item);
 
         $combined_params = $meta_params->merge($manipulation_params);
@@ -199,20 +210,20 @@ class CloudinaryConverter
         if ($this->hasCombinedManipulationParams()) {
             $transformations_slug = $this->buildTransformationSlug($combined_params);
 
-            if (!empty($transformations_slug)) {
+            if ($transformations_slug !== '') {
                 $url = "{$transformations_slug}/{$url}";
             }
         }
 
-        return $this->baseUrl($item) . $url;
+        return $this->baseUrl().$url;
     }
+
     /**
      * The URL generation.
      *
-     * @param  string $item  Either the ID or path of the image.
-     * @return string
+     * @param  string|AssetsAsset  $item  Either the ID or path of the image.
      */
-    public function generateKenBurnsUrl($item)
+    public function generateKenBurnsUrl(mixed $item): string
     {
         $item = $this->getAsset($item);
         $url = $this->normalizeItem($item);
@@ -222,39 +233,48 @@ class CloudinaryConverter
 
         $url = "{$transformations_slug}/{$url}";
 
-        return $this->baseUrl($item) . $url;
+        return $this->baseUrl().$url;
     }
 
-    private function hasCombinedManipulationParams()
+    private function hasCombinedManipulationParams(): bool
     {
         return $this->getManipulationParams()->isNotEmpty() || $this->default_transformations->isNotEmpty();
     }
 
-    private function getMetaParams($item)
+    private function getMetaParams(AssetsAsset $item): Collection
     {
         $params = collect();
-        $manipulation_params = $this->getManipulationParams($item);
+        $manipulation_params = $this->getManipulationParams();
 
         // Set focus related parameters.
-        if ($item->get('focus')) {
-            [$x_percentage, $y_percentage, $zoom] = explode('-', $item->get('focus'));
+        $focus = $item->get('focus');
+        if (is_string($focus) && $focus !== '') {
+            $parts = explode('-', $focus);
+            if (count($parts) === 3) {
+                [$x_percentage, $y_percentage, $zoomStr] = $parts;
+                if (is_numeric($x_percentage) && is_numeric($y_percentage) && is_numeric($zoomStr)) {
+                    $xPct = (float) $x_percentage;
+                    $yPct = (float) $y_percentage;
+                    $zoom = (float) $zoomStr;
 
-            $x = floor(($x_percentage / 100) * $this->getOriginalWidth($item));
-            $y = floor(($y_percentage / 100) * $this->getOriginalHeight($item));
-            $zoom = floor($zoom * 10) / 10;
+                    $x = (int) floor(($xPct / 100.0) * $this->getOriginalWidth($item));
+                    $y = (int) floor(($yPct / 100.0) * $this->getOriginalHeight($item));
+                    $zoom = floor($zoom * 10.0) / 10.0;
 
-            $params->put('x', $x);
-            $params->put('y', $y);
-            $params->put('zoom', $zoom);
-            $params->put('gravity', 'xy_center');
-        } else if ($manipulation_params->has('crop') && $manipulation_params->get('crop') === 'fill') {
+                    $params->put('x', $x);
+                    $params->put('y', $y);
+                    $params->put('zoom', $zoom);
+                    $params->put('gravity', 'xy_center');
+                }
+            }
+        } elseif ($manipulation_params->has('crop') && $manipulation_params->get('crop') === 'fill') {
             /**
              * When using `fit="crop_focal"` in statamic and NOT defining a focal point, the asset is cropped by glide from the center point.
              * In contrary, when using cloudinary, this is not the case.
              * The following code replicates this behavior.
              */
-            $x = floor(0.5 * $this->getOriginalWidth($item));
-            $y = floor(0.5 * $this->getOriginalHeight($item));
+            $x = (int) floor(0.5 * $this->getOriginalWidth($item));
+            $y = (int) floor(0.5 * $this->getOriginalHeight($item));
             $zoom = 1;
 
             $params->put('x', $x);
@@ -269,19 +289,17 @@ class CloudinaryConverter
     /**
      * Get the tag parameters applicable to image manipulation.
      *
-     * @return \Illuminate\Support\Collection
+     * @return Collection<string, mixed>
      */
-    public function getManipulationParams()
+    public function getManipulationParams(): Collection
     {
         $params = collect();
 
-        foreach ($this->params as $param => $value) {
-            if (!in_array($param, ['src', 'id', 'path', 'tag', 'alt'])) {
-                switch ($param) {
-                    case 'format':
-                        $params->put('fetch_format', $value);
-                        break;
+        $excluded = ['src', 'id', 'path', 'tag', 'alt'];
 
+        foreach ($this->params as $param => $value) {
+            if (! in_array($param, $excluded, true)) {
+                switch ($param) {
                     case 'square':
                         $params->put('width', $value);
                         $params->put('aspect_ratio', '1:1');
@@ -317,92 +335,109 @@ class CloudinaryConverter
         return $params;
     }
 
-    private function getOriginalWidth(AssetsAsset $item)
+    private function getOriginalWidth(AssetsAsset $item): int
     {
-        return $item->meta('width');
+        $width = $item->meta('width');
+
+        return is_numeric($width) ? (int) $width : 0;
     }
 
-    private function getOriginalHeight(AssetsAsset $item)
+    private function getOriginalHeight(AssetsAsset $item): int
     {
-        return $item->meta('height');
+        $height = $item->meta('height');
+
+        return is_numeric($height) ? (int) $height : 0;
     }
 
-    private function getOriginalAspectRatio(AssetsAsset $item)
+    private function getOriginalAspectRatio(AssetsAsset $item): float
     {
         $width = $this->getOriginalWidth($item);
         $height = $this->getOriginalHeight($item);
 
-        if (!$width || !$height) {
-            return 1;
+        if ($width === 0 || $height === 0) {
+            return 1.0;
         }
 
         return $width / $height;
     }
 
-    public function getFinalDimensions($item)
+    /**
+     * @return array{0: int, 1: int}
+     */
+    public function getFinalDimensions(mixed $item): array
     {
         $item = $this->getAsset($item);
         $width = (int) $this->getManipulationParams()->get('width');
         $height = (int) $this->getManipulationParams()->get('height');
-        $aspect_ratio =
-            (int) $this->getManipulationParams()->get('aspect_ratio') ?: $this->getOriginalAspectRatio($item);
+        $aspect_ratio = $this->resolveAspectRatio(
+            $this->getManipulationParams()->get('aspect_ratio'),
+            $item
+        );
 
-        if ($width && $height) {
+        if ($width !== 0 && $height !== 0) {
             return [$width, $height];
         }
 
-        if ($width) {
-            return [$width, round($width / $aspect_ratio)];
+        if ($width !== 0) {
+            return [$width, (int) round($width / $aspect_ratio)];
         }
 
-        if ($height) {
-            return [round($height * $aspect_ratio), $height];
+        if ($height !== 0) {
+            return [(int) round($height * $aspect_ratio), $height];
         }
 
         return [0, 0];
     }
 
     /**
-     * Normalize an item to be passed into the manipulator.
-     *
-     * @param  string $item  An asset ID, asset URL, or external URL.
-     * @return string|Statamic\Contracts\Assets\Asset
+     * Resolve aspect ratio from manipulation params (e.g. "16:9") or fall back to the asset.
      */
-    private function normalizeItem($item)
+    private function resolveAspectRatio(mixed $aspectRatio, AssetsAsset $item): float
     {
-        // Double colons indicate an asset ID.
-        if (Str::contains($item, '::')) {
-            $item = Asset::find($item);
+        if ($aspectRatio === null || $aspectRatio === '') {
+            return $this->getOriginalAspectRatio($item);
         }
 
-        $item = Str::ensureLeft(Str::removeLeft($item, '/'), $this->configuration->get('auto_mapping_folder'));
-
-        if ($this->configuration->get('external_url_prefix')) {
-            $item = Str::replace(Str::ensureRight($this->configuration->get('external_url_prefix'), '/'), '', $item);
+        if (is_string($aspectRatio) && str_contains($aspectRatio, ':')) {
+            [$w, $h] = explode(':', $aspectRatio, 2);
+            if (is_numeric($w) && is_numeric($h) && (float) $h !== 0.0) {
+                return (float) $w / (float) $h;
+            }
         }
 
-        return $item;
+        if (is_numeric($aspectRatio)) {
+            return (float) $aspectRatio;
+        }
+
+        return $this->getOriginalAspectRatio($item);
     }
 
-    /**
-     * The list of allowed file formats based on the configured driver.
-     *
-     * @return array
-     */
-    private function allowedFileFormats()
+    private function normalizeItem(AssetsAsset $item): string
     {
-        return ['jpeg', 'jpg', 'png', 'gif', 'tif', 'bmp', 'psd', 'webp'];
+        $path = ltrim($item->path(), '/');
+
+        $path = Str::ensureLeft($path, (string) $this->configuration->get('auto_mapping_folder'));
+
+        if ($this->configuration->get('external_url_prefix')) {
+            $path = Str::replace(Str::ensureRight((string) $this->configuration->get('external_url_prefix'), '/'), '', $path);
+        }
+
+        return $path;
     }
 
     /**
      * Build a Cloudinary transformation slug from arguments.
      *
-     * @param  array $args
-     * @return string
+     * @param  Collection<string, mixed>|array<string, mixed>|null  $args
      */
-    public function buildTransformationSlug($args = null)
+    public function buildTransformationSlug(Collection|array|null $args = null): string
     {
-        if (!$args || !$args instanceof Collection) {
+        if ($args === null) {
+            return '';
+        }
+
+        $args = collect($args);
+        if ($args->isEmpty()) {
             return '';
         }
 
@@ -415,65 +450,62 @@ class CloudinaryConverter
 
         $fetch_format = null;
         if ($args->get('fetch_format')) {
-            $fetch_format = $this->cloudinary_params->get('fetch_format') . '_' . $args->get('fetch_format');
+            $fetch_format = $this->cloudinary_params->get('fetch_format').'_'.$args->get('fetch_format');
             $args->forget('fetch_format');
         }
 
         $quality = null;
         if ($args->get('quality')) {
-            $quality = $this->cloudinary_params->get('quality') . '_' . $args->get('quality');
+            $quality = $this->cloudinary_params->get('quality').'_'.$args->get('quality');
             $args->forget('quality');
         }
 
         $slug = $args
-            ->map(function ($value, $key) {
+            ->map(function ($value, string $key): ?string {
                 if (
-                    $this->cloudinary_params->has($key) &&
-                    $this->isValidCloudinaryParam($this->cloudinary_params->get($key), $value)
+                    ! $this->cloudinary_params->has($key) ||
+                    ! $this->isValidCloudinaryParam((string) $this->cloudinary_params->get($key), $value)
                 ) {
-                    switch ($key) {
-                        case 'progressive':
-                            if (true === $value) {
-                                return $this->cloudinary_params->get($key);
-                            } else {
-                                return $this->cloudinary_params->get($key) . ':' . $value;
-                            }
-                            break;
-                        default:
-                            return $this->cloudinary_params->get($key) . '_' . $value;
-                    }
-                } else {
-                    Log::warning('Unknown Cloudinary parameter [' . $key . '] for asset ');
+                    Log::warning('Unknown Cloudinary parameter ['.$key.'] for Cloudinary transformation slug');
+
+                    return null;
                 }
+
+                $shortKey = (string) $this->cloudinary_params->get($key);
+
+                if ($key === 'progressive') {
+                    return $value === true ? $shortKey : $shortKey.':'.$value;
+                }
+
+                return $shortKey.'_'.$value;
             })
             ->filter();
 
         $transformation_slug = $slug->implode(urlencode(','));
-        if ($quality) {
-            $transformation_slug = $transformation_slug . '/' . $quality;
+        if ($quality !== null) {
+            $transformation_slug = $transformation_slug.'/'.$quality;
         }
-        if ($fetch_format) {
-            $transformation_slug = $transformation_slug . '/' . $fetch_format;
+        if ($fetch_format !== null) {
+            $transformation_slug = $transformation_slug.'/'.$fetch_format;
         }
 
         return $transformation_slug;
     }
 
-    public function getDefaultTransformationByType($type)
+    /**
+     * @return mixed
+     */
+    public function getDefaultTransformationByType(?string $type)
     {
         return $this->default_transformations->get($type);
     }
 
     /**
      * Check if the value is valid.
-     *
-     * @param string $key
-     * @param string $value
-     * @return bool
      */
-    public function isValidCloudinaryParam($key = '', $value = '')
+    public function isValidCloudinaryParam(string $key = '', mixed $value = null): bool
     {
-        if (('w' === $key || 'h' === $key) && empty($value)) {
+        if (($key === 'w' || $key === 'h') && ($value === null || $value === '')) {
             return false;
         }
 

--- a/src/Converter/CloudinaryConverter.php
+++ b/src/Converter/CloudinaryConverter.php
@@ -371,7 +371,7 @@ class CloudinaryConverter
         $height = (int) $this->getManipulationParams()->get('height');
         $aspect_ratio = $this->resolveAspectRatio(
             $this->getManipulationParams()->get('aspect_ratio'),
-            $item
+            $item,
         );
 
         if ($width !== 0 && $height !== 0) {
@@ -414,8 +414,7 @@ class CloudinaryConverter
 
     private function normalizeItem(AssetsAsset $item): string
     {
-        $path = ltrim($item->path(), '/');
-
+        $path = ltrim($item->absoluteUrl(), '/');
         $path = Str::ensureLeft($path, (string) $this->configuration->get('auto_mapping_folder'));
 
         if ($this->configuration->get('external_url_prefix')) {

--- a/src/Converter/CloudinaryConverter.php
+++ b/src/Converter/CloudinaryConverter.php
@@ -1,7 +1,6 @@
 <?php
 
 declare(strict_types=1);
-
 namespace TFD\Cloudinary\Converter;
 
 use Illuminate\Support\Collection;

--- a/src/Interfaces/CloudinaryInterface.php
+++ b/src/Interfaces/CloudinaryInterface.php
@@ -1,10 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace TFD\Cloudinary\Interfaces;
 
 use TFD\Cloudinary\Converter\CloudinaryConverter;
 
 interface CloudinaryInterface
 {
-    public function setConverter($converter);
+    public function setConverter(CloudinaryConverter $converter): void;
 }

--- a/src/Interfaces/CloudinaryInterface.php
+++ b/src/Interfaces/CloudinaryInterface.php
@@ -1,7 +1,6 @@
 <?php
 
 declare(strict_types=1);
-
 namespace TFD\Cloudinary\Interfaces;
 
 use TFD\Cloudinary\Converter\CloudinaryConverter;

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -1,7 +1,6 @@
 <?php
 
 declare(strict_types=1);
-
 namespace TFD\Cloudinary;
 
 use Illuminate\Support\Facades\Blade;

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -46,6 +46,7 @@ class ServiceProvider extends AddonServiceProvider
             __DIR__.'/../resources/views' => resource_path('views/vendor/cloudinary'),
         ], 'cloudinary-views');
 
+        Blade::component('image', Image::class);
         Blade::component('cloudinary-image', Image::class);
         $this->loadViewComponentsAs('cloudinary-image', [
             Image::class,

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace TFD\Cloudinary;
 
 use Illuminate\Support\Facades\Blade;
@@ -13,28 +15,40 @@ class ServiceProvider extends AddonServiceProvider
         Cloudinary::class,
     ];
 
-    public function boot()
-    {
-        parent::boot();
+    /**
+     * Use 'cloudinary' so the parent's bootViews() loads addon views under this namespace.
+     */
+    protected $viewNamespace = 'cloudinary';
 
-        $this->bootAddonConfig();
+    /**
+     * Disable parent's default config (merge/publish to config/cloudinary.php).
+     * We use config('statamic.cloudinary') and publish to config/statamic/cloudinary.php in bootAddon().
+     */
+    protected $config = false;
+
+    /**
+     * Boot the addon. This runs after Statamic has booted (called from the parent's
+     * Statamic::booted() callback). Prefer bootAddon() over overriding boot() so
+     * that addon logic runs in the correct lifecycle.
+     */
+    public function bootAddon(): void
+    {
+        $this->mergeConfigFrom(
+            __DIR__.'/../config/cloudinary.php',
+            'statamic.cloudinary'
+        );
 
         $this->publishes([
             __DIR__.'/../config/cloudinary.php' => config_path('statamic/cloudinary.php'),
         ], 'cloudinary-config');
+
         $this->publishes([
-            __DIR__ . '/../resources/views' => resource_path('views/vendor/cloudinary'),
+            __DIR__.'/../resources/views' => resource_path('views/vendor/cloudinary'),
         ], 'cloudinary-views');
 
-
-        Blade::component('image', Image::class);
-        $this->loadViewsFrom(__DIR__ . '/../resources/views', 'cloudinary');
-        $this->loadViewComponentsAs('cloudinary', [
+        Blade::component('cloudinary-image', Image::class);
+        $this->loadViewComponentsAs('cloudinary-image', [
             Image::class,
         ]);
-    }
-
-    protected function bootAddonConfig()
-    {
     }
 }

--- a/src/Tags/Cloudinary.php
+++ b/src/Tags/Cloudinary.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace TFD\Cloudinary\Tags;
 
 use Illuminate\Support\Facades\Log;
@@ -11,28 +13,29 @@ use TFD\Cloudinary\Interfaces\CloudinaryInterface;
 
 class Cloudinary extends Tags implements CloudinaryInterface
 {
-    protected $converter;
-    private $glide;
+    protected CloudinaryConverter $converter;
 
-    public static function resetStaticState()
-    {
-    }
+    private ?Glide $glide = null;
+
+    public static function resetStaticState() {}
 
     public function __construct(CloudinaryConverter $converter)
     {
         $this->setConverter($converter);
     }
 
-    public function setConverter($converter)
+    public function setConverter(CloudinaryConverter $converter): void
     {
         $this->converter = $converter;
     }
 
-    public function setParameters($parameters)
+    public function setParameters($parameters): static
     {
         parent::setParameters($parameters);
 
         $this->converter->setParams($parameters);
+
+        return $this;
     }
 
     public function getGlideFallback()
@@ -40,9 +43,9 @@ class Cloudinary extends Tags implements CloudinaryInterface
         if ($this->params->has('aspect_ratio')) {
             $aspect_ratio = $this->params->get('aspect_ratio');
             $this->params->forget('aspect_ratio');
-            if (str_contains($aspect_ratio, ':')) {
-                [$ratio_width, $ratio_height] = explode(':', $aspect_ratio);
-                $aspect_ratio = $ratio_width / $ratio_height;
+            if (is_string($aspect_ratio) && str_contains($aspect_ratio, ':')) {
+                [$ratio_width, $ratio_height] = explode(':', $aspect_ratio, 2);
+                $aspect_ratio = (float) $ratio_width / (float) $ratio_height;
             }
             if ($this->params->has('width')) {
                 $this->params->put('height', $this->params->get('width') / $aspect_ratio);
@@ -55,8 +58,8 @@ class Cloudinary extends Tags implements CloudinaryInterface
             $this->params->put('format', 'jpg');
         }
 
-        if (!$this->glide) {
-            $this->glide = new Glide();
+        if (! $this->glide) {
+            $this->glide = new Glide;
             $this->glide->setProperties([
                 'parser' => $this->parser,
                 'content' => $this->content,
@@ -66,6 +69,7 @@ class Cloudinary extends Tags implements CloudinaryInterface
                 'tag_method' => $this->method,
             ]);
         }
+
         return $this->glide;
     }
 
@@ -74,17 +78,15 @@ class Cloudinary extends Tags implements CloudinaryInterface
      *
      * Where `field` is the variable containing the image ID
      *
-     * @param  $method
-     * @param  $args
-     * @return string
+     * @return string|array<int, array<string, mixed>|string>
      */
-    public function wildcard()
+    public function wildcard($tag)
     {
-        if (!$this->converter->hasValidConfiguration()) {
+        if (! $this->converter->hasValidConfiguration()) {
             return $this->getGlideFallback()->wildcard();
         }
 
-        $tag = explode(':', $this->tag, 2)[1];
+        $tag = $tag ?? explode(':', $this->tag, 2)[1];
         if ($tag === 'ken_burns' || $tag === 'kenburns') {
             return $this->kenBurns();
         }
@@ -102,66 +104,64 @@ class Cloudinary extends Tags implements CloudinaryInterface
 
             return $this->getGlideFallback()->wildcard();
         }
+
         return $this->output($this->converter->generateCloudinaryUrl($item));
     }
 
     /**
      * The {{ cloudinary }} tag.
      *
-     * @return string|array
+     * @return string|array|bool
      */
     public function index()
     {
-        if (!$this->converter->hasValidConfiguration()) {
+        if (! $this->converter->hasValidConfiguration()) {
             return $this->getGlideFallback()->index();
         }
 
-        if (!($src = $this->params->get('src'))) {
+        if (! ($src = $this->params->get('src'))) {
             return $this->sourceIsEmptyError();
-        } else {
-            $item = $this->converter->getAsset($src);
-
-            try {
-                $this->converter->setAssetType($item);
-            } catch (ItemNotFoundException $e) {
-                Log::error($e->getMessage());
-
-                return $this->getGlideFallback()->index();
-            }
-            return $this->output($this->converter->generateCloudinaryUrl($item));
         }
 
-        return $this->getGlideFallback()->index();
-    }
+        $item = $this->converter->getAsset($src);
 
+        try {
+            $this->converter->setAssetType($item);
+        } catch (ItemNotFoundException $e) {
+            Log::error($e->getMessage());
+
+            return $this->getGlideFallback()->index();
+        }
+
+        return $this->output($this->converter->generateCloudinaryUrl($item));
+    }
 
     /**
      * The {{ cloudinary:ken_burns }} tag.
      *
-     * @return string|array
+     * @return string|array|bool
      */
     public function kenBurns()
     {
-        if (!$this->converter->hasValidConfiguration()) {
+        if (! $this->converter->hasValidConfiguration()) {
             return $this->getGlideFallback()->index();
         }
 
-        if (!($src = $this->params->get('src'))) {
+        if (! ($src = $this->params->get('src'))) {
             return $this->sourceIsEmptyError();
-        } else {
-            $item = $this->converter->getAsset($src);
-
-            try {
-                $this->converter->setAssetType($item);
-            } catch (ItemNotFoundException $e) {
-                Log::error($e->getMessage());
-
-                return $this->getGlideFallback()->index();
-            }
-            return $this->output($this->converter->generateKenBurnsUrl($item));
         }
 
-        return $this->getGlideFallback()->index();
+        $item = $this->converter->getAsset($src);
+
+        try {
+            $this->converter->setAssetType($item);
+        } catch (ItemNotFoundException $e) {
+            Log::error($e->getMessage());
+
+            return $this->getGlideFallback()->index();
+        }
+
+        return $this->output($this->converter->generateKenBurnsUrl($item));
     }
 
     /**
@@ -169,7 +169,7 @@ class Cloudinary extends Tags implements CloudinaryInterface
      *
      * Generates the image and makes variables available within the pair.
      *
-     * @return string
+     * @return array<int, array<string, mixed>|string>
      */
     public function generate($items = null)
     {
@@ -200,14 +200,28 @@ class Cloudinary extends Tags implements CloudinaryInterface
 
     /**
      * Output the tag.
-     *
-     * @param string $url
-     * @return string
      */
-    private function output($url)
+    private function output(string $url): string
     {
         if ($this->isPair) {
-            return $this->parse(compact('url', 'width', 'height'));
+            $src = $this->params->get('src')
+                ?? $this->params->get('id')
+                ?? $this->params->get('path');
+
+            if ($src === null || $src === '') {
+                return $this->parse(compact('url'));
+            }
+
+            try {
+                $item = $this->converter->getAsset($src);
+                [$width, $height] = $this->converter->getFinalDimensions($item);
+
+                return $this->parse(compact('url', 'width', 'height'));
+            } catch (ItemNotFoundException $e) {
+                Log::error($e->getMessage());
+
+                return $this->parse(compact('url'));
+            }
         }
         if ($this->params->bool('tag')) {
             return "<img src=\"$url\" alt=\"{$this->params->get('alt')}\" />";
@@ -218,23 +232,23 @@ class Cloudinary extends Tags implements CloudinaryInterface
 
     /**
      * Error Log for src is empty.
-     *
-     * @return bool
      */
-    private function sourceIsEmptyError()
+    private function sourceIsEmptyError(): bool
     {
         $additionalInformation = [];
 
-        try {
-            $additionalInformation[] = 'field_id:[' . $this->context['id'] . ']';
-            $additionalInformation[] = 'page_id:[' . $this->context['page']->id . ']';
-        } catch (\Throwable $th) {
+        if (isset($this->context['id'])) {
+            $additionalInformation[] = 'field_id:['.$this->context['id'].']';
+        }
 
+        if (isset($this->context['page']) && is_object($this->context['page']) && isset($this->context['page']->id)) {
+            $additionalInformation[] = 'page_id:['.$this->context['page']->id.']';
         }
 
         $additionalInformation = implode(', ', $additionalInformation);
 
         Log::error("Cloudinary parameter \"src\" is empty | Context: $additionalInformation");
+
         return false;
     }
 }

--- a/src/Tags/Cloudinary.php
+++ b/src/Tags/Cloudinary.php
@@ -1,7 +1,6 @@
 <?php
 
 declare(strict_types=1);
-
 namespace TFD\Cloudinary\Tags;
 
 use Illuminate\Support\Facades\Log;
@@ -17,7 +16,9 @@ class Cloudinary extends Tags implements CloudinaryInterface
 
     private ?Glide $glide = null;
 
-    public static function resetStaticState() {}
+    public static function resetStaticState()
+    {
+    }
 
     public function __construct(CloudinaryConverter $converter)
     {

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+use Tests\TestCase;
+
+uses(TestCase::class)->in('Unit');

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests;
+
+use Orchestra\Testbench\TestCase as Orchestra;
+
+abstract class TestCase extends Orchestra
+{
+    protected function defineEnvironment($app): void
+    {
+        $app['config']->set('app.key', 'base64:'.base64_encode(random_bytes(32)));
+        $app['config']->set('statamic.cloudinary', require dirname(__DIR__).'/config/cloudinary.php');
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,7 +1,6 @@
 <?php
 
 declare(strict_types=1);
-
 namespace Tests;
 
 use Orchestra\Testbench\TestCase as Orchestra;

--- a/tests/Unit/CloudinaryConverterTest.php
+++ b/tests/Unit/CloudinaryConverterTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+use Statamic\Assets\Asset;
+use TFD\Cloudinary\Converter\CloudinaryConverter;
+
+it('returns empty string from buildTransformationSlug when args is null', function () {
+    $converter = app(CloudinaryConverter::class);
+
+    expect($converter->buildTransformationSlug(null))->toBe('');
+});
+
+it('returns empty string from buildTransformationSlug when args is an empty array', function () {
+    $converter = app(CloudinaryConverter::class);
+
+    expect($converter->buildTransformationSlug([]))->toBe('');
+});
+
+it('buildTransformationSlug accepts array input and includes width transformation', function () {
+    $converter = app(CloudinaryConverter::class);
+    $reflection = new ReflectionClass($converter);
+    $property = $reflection->getProperty('asset_type');
+    $property->setAccessible(true);
+    $property->setValue($converter, 'image');
+
+    expect($converter->buildTransformationSlug(['width' => 100]))->toContain('w_100');
+});
+
+it('rejects empty width or height cloudinary params', function () {
+    $converter = app(CloudinaryConverter::class);
+
+    expect($converter->isValidCloudinaryParam('w', ''))->toBeFalse();
+    expect($converter->isValidCloudinaryParam('h', null))->toBeFalse();
+    expect($converter->isValidCloudinaryParam('w', '200'))->toBeTrue();
+});
+
+it('resolves aspect ratio strings for final dimensions', function () {
+    $converter = app(CloudinaryConverter::class);
+    $converter->setParams(['width' => 400, 'aspect_ratio' => '16:9']);
+
+    $reflection = new ReflectionClass($converter);
+    $method = $reflection->getMethod('resolveAspectRatio');
+    $method->setAccessible(true);
+
+    $asset = Mockery::mock(Asset::class);
+    $asset->shouldReceive('meta')->with('width')->andReturn(1920);
+    $asset->shouldReceive('meta')->with('height')->andReturn(1080);
+
+    $ratio = $method->invoke($converter, '16:9', $asset);
+
+    expect($ratio)->toBeFloat();
+    expect(round($ratio, 5))->toBe(round(16 / 9, 5));
+});


### PR DESCRIPTION
## Summary
- add a dedicated Blade component flow for Cloudinary images and align service provider/view registration
- harden Cloudinary URL generation, parameter handling, typing, and Glide fallback behavior across tags and converter logic
- preserve backward compatibility for the legacy Blade component alias and published component view override
- add Pest/Testbench coverage, refresh repository documentation, and restore PHP CS Fixer v3 compatibility

## Testing
- composer lint
- composer test