### PR TITLE
fix: forward the field argument to the Glide wildcard fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,6 +84,7 @@ $RECYCLE.BIN/
 # End of https://www.toptal.com/developers/gitignore/api/visualstudiocode,macos,windows,composer
 
 .php_cs.cache
+.php-cs-fixer.cache
 node_modules
 vendor
 mix-manifest.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ Guidance for coding agents working in `tfd/statamic-cloudinary`.
 - Package runtime config lives in `config/cloudinary.php` and is published to `config/statamic/cloudinary.php`.
 - Blade views live in `resources/views/`.
 - There is no frontend build pipeline for this addon.
-- Tests use Pest with Orchestra Testbench in `tests/`, for example `tests/Unit/CloudinaryConverterTest.php`.
+- Tests use Pest in `tests/`, for example `tests/Unit/CloudinaryConverterTest.php`. `Tests\TestCase` extends Statamic's `AddonTestCase`, so Statamic and this addon's service provider are booted — tags that run Statamic hooks need that.
 
 ## Rule Sources
 
@@ -99,7 +99,9 @@ Run filtered tests:
 ./vendor/bin/pest --filter=CloudinaryConverter
 ```
 
-Test config lives in `phpunit.xml`; `tests/Pest.php` binds `Tests\TestCase` for `tests/Unit`.
+Test config lives in `phpunit.xml`; `tests/Pest.php` binds `Tests\TestCase` for `tests/Unit`. Test doubles live in `tests/Fixtures/`.
+
+The test harness runs on Laravel 12 (`orchestra/testbench ^10`). The package itself still declares support for Statamic `^5`, whose Laravel 10/11 range is therefore not covered by a test run — there is no CI matrix.
 
 ## Files And Responsibilities
 

--- a/composer.json
+++ b/composer.json
@@ -34,10 +34,10 @@
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^3.88",
     "mockery/mockery": "^1.6",
-    "orchestra/testbench": "^9.0",
-    "pestphp/pest": "^2.36",
-    "pestphp/pest-plugin-laravel": "^2.4",
-    "phpunit/phpunit": "^10.5",
+    "orchestra/testbench": "^10.0",
+    "pestphp/pest": "^3.8",
+    "pestphp/pest-plugin-laravel": "^3.2",
+    "phpunit/phpunit": "^11.5",
     "squizlabs/php_codesniffer": "^3.6"
   },
   "scripts": {

--- a/src/Tags/Cloudinary.php
+++ b/src/Tags/Cloudinary.php
@@ -84,7 +84,7 @@ class Cloudinary extends Tags implements CloudinaryInterface
     public function wildcard($tag)
     {
         if (! $this->converter->hasValidConfiguration()) {
-            return $this->getGlideFallback()->wildcard();
+            return $this->getGlideFallback()->wildcard($tag);
         }
 
         $tag = $tag ?? explode(':', $this->tag, 2)[1];
@@ -103,7 +103,7 @@ class Cloudinary extends Tags implements CloudinaryInterface
         } catch (ItemNotFoundException $e) {
             Log::error($e->getMessage());
 
-            return $this->getGlideFallback()->wildcard();
+            return $this->getGlideFallback()->wildcard($tag);
         }
 
         return $this->output($this->converter->generateCloudinaryUrl($item));

--- a/tests/Fixtures/RecordingGlide.php
+++ b/tests/Fixtures/RecordingGlide.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+namespace Tests\Fixtures;
+
+use Statamic\Tags\Glide;
+
+/**
+ * A Glide tag that records how it was called instead of generating URLs.
+ *
+ * `wildcard()` deliberately keeps Glide's required `$method` parameter: a
+ * fallback called without an argument has to raise `ArgumentCountError`,
+ * which is the regression this double exists to catch. Do not give it a
+ * default value.
+ */
+class RecordingGlide extends Glide
+{
+    public const URL = '/img/glide-fallback.jpg';
+
+    /**
+     * @var array<int, mixed>
+     */
+    public array $wildcardCalls = [];
+
+    public function wildcard($method)
+    {
+        $this->wildcardCalls[] = $method;
+
+        return self::URL;
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,10 +3,13 @@
 declare(strict_types=1);
 namespace Tests;
 
-use Orchestra\Testbench\TestCase as Orchestra;
+use Statamic\Testing\AddonTestCase;
+use TFD\Cloudinary\ServiceProvider;
 
-abstract class TestCase extends Orchestra
+abstract class TestCase extends AddonTestCase
 {
+    protected string $addonServiceProvider = ServiceProvider::class;
+
     protected function defineEnvironment($app): void
     {
         $app['config']->set('app.key', 'base64:'.base64_encode(random_bytes(32)));

--- a/tests/Unit/CloudinaryTagTest.php
+++ b/tests/Unit/CloudinaryTagTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\ItemNotFoundException;
+use Statamic\Tags\Glide;
+use Tests\Fixtures\RecordingGlide;
+use TFD\Cloudinary\Converter\CloudinaryConverter;
+use TFD\Cloudinary\Tags\Cloudinary;
+
+/**
+ * Build the tag with the given converter and pin a recording Glide fallback
+ * onto it, so the fallback branches can be asserted without Glide's imaging
+ * stack.
+ *
+ * @return array{0: Cloudinary, 1: RecordingGlide}
+ */
+function cloudinaryTagWithRecordingGlide(CloudinaryConverter $converter, array $context): array
+{
+    $properties = [
+        'parser' => null,
+        'content' => '',
+        'context' => $context,
+        'params' => ['width' => 100],
+        'tag' => 'cloudinary:teaser_image',
+        'tag_method' => 'teaser_image',
+    ];
+
+    $tag = new Cloudinary($converter);
+    $tag->setProperties($properties);
+
+    $glide = new RecordingGlide;
+    $glide->setProperties($properties);
+
+    $property = new ReflectionProperty($tag, 'glide');
+    $property->setAccessible(true);
+    $property->setValue($tag, $glide);
+
+    return [$tag, $glide];
+}
+
+it('falls back to the glide wildcard tag when cloudinary is not configured', function ($argument) {
+    config()->set('statamic.cloudinary.cloud_name', null);
+
+    $converter = app(CloudinaryConverter::class);
+    expect($converter->hasValidConfiguration())->toBeFalse();
+
+    [$tag, $glide] = cloudinaryTagWithRecordingGlide($converter, ['teaser_image' => 'some-image.jpg']);
+
+    expect($tag->wildcard($argument))->toBe(RecordingGlide::URL);
+    expect($glide->wildcardCalls)->toBe([$argument]);
+})->with([
+    'field name' => 'teaser_image',
+    // Statamic passes the method name, but a null argument must not break the
+    // fallback either - the guard runs before the field is resolved.
+    'null' => null,
+]);
+
+it('falls back to the glide wildcard tag when the asset cannot be found', function () {
+    Log::shouldReceive('error')->once();
+
+    $converter = Mockery::mock(CloudinaryConverter::class);
+    $converter->shouldReceive('setParams');
+    $converter->shouldReceive('hasValidConfiguration')->andReturnTrue();
+    $converter->shouldReceive('setAssetType')
+        ->andThrow(new ItemNotFoundException('Asset not found for string'));
+
+    [$tag, $glide] = cloudinaryTagWithRecordingGlide($converter, [
+        'teaser_image' => 'this-asset-does-not-exist-9f3a.jpg',
+    ]);
+
+    expect($tag->wildcard('teaser_image'))->toBe(RecordingGlide::URL);
+    expect($glide->wildcardCalls)->toBe(['teaser_image']);
+});
+
+/*
+ * The two tests above only catch the missing argument because the double keeps
+ * Glide's arity. Pin that to the real tag instead of to a comment, so an
+ * upstream signature change surfaces here rather than silently defusing them.
+ */
+it('keeps the recording glide double in step with the real glide signature', function () {
+    $real = new ReflectionMethod(Glide::class, 'wildcard');
+    $double = new ReflectionMethod(RecordingGlide::class, 'wildcard');
+
+    expect($real->getNumberOfRequiredParameters())->toBe(1);
+    expect($double->getNumberOfRequiredParameters())
+        ->toBe($real->getNumberOfRequiredParameters());
+});


### PR DESCRIPTION
Closes #29

## The bug

`Tags\Cloudinary::wildcard()` called `Glide::wildcard()` without its required `$method` argument at both fallback sites, so instead of degrading gracefully to Glide it raised `ArgumentCountError`:

- `src/Tags/Cloudinary.php:87` — unconfigured install: every `{{ cloudinary:field }}` tag 500s, which makes the addon unusable rather than transparently falling back.
- `src/Tags/Cloudinary.php:106` — correctly configured install: a single missing or renamed asset turns into a 500 in production.

## The fix

Forward `$tag` at both sites, as the issue suggests. `Glide::wildcard()` ignores the argument and re-derives the field from `$this->tag`, so the value only needs to satisfy the signature.

The `index()` and `kenBurns()` fallbacks were checked and are fine — `Glide::index()` takes no arguments.

## Tests

First test coverage for `Tags\Cloudinary` (`tests/Unit/CloudinaryTagTest.php`). Written test-first: the red run reproduced the reported `ArgumentCountError` at both line numbers.

- both fallback branches from the issue — unconfigured, and configured-but-asset-missing
- a guard pinning the `RecordingGlide` double's arity to the real `Statamic\Tags\Glide`, so an upstream signature change surfaces here instead of silently defusing the regression tests

9 tests / 19 assertions green, PHP CS Fixer clean.

## Two things worth a look before merging

**The dev toolchain was broken independently of this issue.** `require-dev` asked for `orchestra/testbench ^9` (Laravel 11), which is uninstallable because those Laravel releases are blocked by security advisories — so Pest, Testbench and Mockery were absent from `vendor/` entirely and no test could run. Bumped to the versions matching the locked Laravel 12: `testbench ^10`, `pest ^3.8`, `pest-plugin-laravel ^3.2`, `phpunit ^11.5`.

**That leaves a coverage gap.** The harness now runs on Laravel 12, while `require` still allows `statamic/cms ^5.73.11` (Laravel 10/11). That half of the declared support range is covered by no test run, and there is no CI workflow to spread a matrix over. Noted in `AGENTS.md` rather than left implicit — whether to keep declaring `^5` is a call for this repo.

## Also included

- `tests/TestCase.php` extends Statamic's `AddonTestCase`: `Tags::setProperties()` runs Statamic hooks, which need the service providers booted. The pre-existing converter tests still pass.
- `.php-cs-fixer.cache` added to `.gitignore` — only `.php_cs.cache`, the old tool name, was listed.
- `AGENTS.md`: corrected the test-harness description, which no longer matched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SxQTYv358Byx9hVzs4EcEK
